### PR TITLE
Use capability_technology join table for capability lookups

### DIFF
--- a/src/main/java/com/example/capabilities/infrastructure/mapper/TechnologiesMapper.java
+++ b/src/main/java/com/example/capabilities/infrastructure/mapper/TechnologiesMapper.java
@@ -1,40 +1,28 @@
 package com.example.capabilities.infrastructure.mapper;
 
-import com.example.capabilities.domain.model.*;
+import com.example.capabilities.domain.model.Capabilities;
 import com.example.capabilities.infrastructure.repository.documents.CapabilitiesEntity;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class TechnologiesMapper {
   private TechnologiesMapper() {}
 
-  public static Capabilities toDomain(CapabilitiesEntity item){
+  public static Capabilities toDomain(String id, String name, String description, List<String> technologies){
     return new Capabilities(
-            item.getId(),
-            item.getName(),
-            item.getDescription(),
-            parseTechnologies(item.getTechnologies())
+            id,
+            name,
+            description,
+            technologies
     );
   }
+
   public static CapabilitiesEntity toEntity(Capabilities domain){
     var entity = new CapabilitiesEntity();
     entity.setId(domain.id());
     entity.setName(domain.name());
     entity.setDescription(domain.description());
-    entity.setTechnologies(String.join(",", domain.technologies()));
     return entity;
-  }
-
-  private static List<String> parseTechnologies(String raw) {
-    if (raw == null || raw.isBlank()) {
-      return List.of();
-    }
-    return Arrays.stream(raw.split(","))
-        .map(String::trim)
-        .filter(s -> !s.isBlank())
-        .collect(Collectors.toList());
   }
 }
 

--- a/src/main/java/com/example/capabilities/infrastructure/repository/SpringDataCapabilitiesRepository.java
+++ b/src/main/java/com/example/capabilities/infrastructure/repository/SpringDataCapabilitiesRepository.java
@@ -3,12 +3,17 @@ package com.example.capabilities.infrastructure.repository;
 import com.example.capabilities.domain.model.Capabilities;
 import com.example.capabilities.infrastructure.mapper.TechnologiesMapper;
 import com.example.capabilities.infrastructure.repository.documents.CapabilitiesEntity;
-import org.springframework.stereotype.Repository;
+import io.r2dbc.spi.Row;
+import io.r2dbc.spi.RowMetadata;
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
-import org.springframework.data.relational.core.query.Criteria;
-import org.springframework.data.relational.core.query.Query;
+import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Repository
 public class SpringDataCapabilitiesRepository {
@@ -20,25 +25,101 @@ public class SpringDataCapabilitiesRepository {
   }
 
   public Mono<Capabilities> findById(String id){
-    return template.selectOne(Query.query(Criteria.where("id").is(id)), CapabilitiesEntity.class)
-            .map(TechnologiesMapper::toDomain);
+    return template.getDatabaseClient()
+            .sql(BASE_SELECT + " WHERE c.id = :id")
+            .bind("id", id)
+            .map(this::mapRow)
+            .all()
+            .collectList()
+            .flatMap(this::mapSingleResult);
   }
 
   public Mono<Capabilities> findByName(String name){
-    return template.selectOne(Query.query(Criteria.where("name").is(name)), CapabilitiesEntity.class)
-            .map(TechnologiesMapper::toDomain);
+    return template.getDatabaseClient()
+            .sql(BASE_SELECT + " WHERE c.name = :name")
+            .bind("name", name)
+            .map(this::mapRow)
+            .all()
+            .collectList()
+            .flatMap(this::mapSingleResult);
   }
 
   public Mono<Capabilities> save(Capabilities capabilities){
     var entity = TechnologiesMapper.toEntity(capabilities);
     return template.insert(CapabilitiesEntity.class)
             .using(entity)
-            .map(saved -> capabilities);
+            .then(insertCapabilityTechnologies(capabilities.id(), capabilities.technologies()))
+            .thenReturn(capabilities);
   }
 
   public Flux<Capabilities> findAll(){
-    return template.select(Query.empty(), CapabilitiesEntity.class)
-            .map(TechnologiesMapper::toDomain);
+    return template.getDatabaseClient()
+            .sql(BASE_SELECT + " ORDER BY c.name, ct.technology_id")
+            .map(this::mapRow)
+            .all()
+            .transform(this::groupRowsByCapability);
   }
+
+  private Mono<Void> insertCapabilityTechnologies(String capabilityId, List<String> technologies) {
+    return Flux.fromIterable(technologies)
+            .concatMap(technologyId -> template.getDatabaseClient()
+                    .sql("INSERT INTO capability_technology (capability_id, technology_id) VALUES (:capabilityId, :technologyId)")
+                    .bind("capabilityId", capabilityId)
+                    .bind("technologyId", technologyId)
+                    .fetch()
+                    .rowsUpdated())
+            .then();
+  }
+
+  private Flux<Capabilities> groupRowsByCapability(Flux<CapabilityTechnologyRow> rows) {
+    return rows.groupBy(CapabilityTechnologyRow::capabilityId)
+            .concatMap(group -> group.collectList().map(this::mapToDomain));
+  }
+
+  private Mono<Capabilities> mapSingleResult(List<CapabilityTechnologyRow> rows) {
+    if (rows.isEmpty()) {
+      return Mono.empty();
+    }
+    return Mono.fromCallable(() -> mapToDomain(rows));
+  }
+
+  private Capabilities mapToDomain(List<CapabilityTechnologyRow> rows) {
+    var first = rows.get(0);
+    var technologies = rows.stream()
+            .map(CapabilityTechnologyRow::technologyId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    return TechnologiesMapper.toDomain(
+            first.capabilityId(),
+            first.capabilityName(),
+            first.capabilityDescription(),
+            List.copyOf(technologies)
+    );
+  }
+
+  private CapabilityTechnologyRow mapRow(Row row, RowMetadata metadata) {
+    return new CapabilityTechnologyRow(
+            row.get("capability_id", String.class),
+            row.get("capability_name", String.class),
+            row.get("capability_description", String.class),
+            row.get("technology_id", String.class)
+    );
+  }
+
+  private record CapabilityTechnologyRow(
+          String capabilityId,
+          String capabilityName,
+          String capabilityDescription,
+          String technologyId
+  ) {}
+
+  private static final String BASE_SELECT = """
+      SELECT c.id AS capability_id,
+             c.name AS capability_name,
+             c.description AS capability_description,
+             ct.technology_id AS technology_id
+      FROM capabilities c
+      INNER JOIN capability_technology ct ON c.id = ct.capability_id
+      """;
 }
 

--- a/src/main/java/com/example/capabilities/infrastructure/repository/documents/CapabilitiesEntity.java
+++ b/src/main/java/com/example/capabilities/infrastructure/repository/documents/CapabilitiesEntity.java
@@ -1,7 +1,6 @@
 package com.example.capabilities.infrastructure.repository.documents;
 
 import org.springframework.data.annotation.Id;
-import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("capabilities")
@@ -10,14 +9,9 @@ public class CapabilitiesEntity {
     @Id
     private String id;
 
-    @Column("name")
     private String name;
 
-    @Column("description")
     private String description;
-
-    @Column("technologies")
-    private String technologies;
 
     public String getId() {
         return id;
@@ -41,13 +35,5 @@ public class CapabilitiesEntity {
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public String getTechnologies() {
-        return technologies;
-    }
-
-    public void setTechnologies(String technologies) {
-        this.technologies = technologies;
     }
 }

--- a/src/main/resources/db/migration/V3__create_capability_technology_table.sql
+++ b/src/main/resources/db/migration/V3__create_capability_technology_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS capability_technology (
+    capability_id VARCHAR(36) NOT NULL,
+    technology_id VARCHAR(36) NOT NULL,
+    PRIMARY KEY (capability_id, technology_id),
+    FOREIGN KEY (capability_id) REFERENCES capabilities(id) ON DELETE CASCADE,
+    FOREIGN KEY (technology_id) REFERENCES technologies(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- update the capabilities persistence layer to resolve technologies through the capability_technology join table
- persist capability-to-technology relationships when saving new capabilities
- add a migration that creates the capability_technology association table and simplify the JPA entity mapping

## Testing
- ./gradlew test *(fails: Gradle distribution download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e424c73cec8320b36502c3b6702407